### PR TITLE
Optomize sending coverage reports to Codecov

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -94,3 +94,5 @@ jobs:
       - name: "Publish coverage report to Codecov"
         uses: "codecov/codecov-action@v1"
         if: ${{ matrix.python-version==3.9 && matrix.php-version==8.0 }}
+        with:
+          name: "php-${{ matrix.php-version }}-composer-${{ matrix.composer-dependencies }}-python-${{ matrix.python-version }}-pygments-${{ matrix.pygments-version }}"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,6 +74,8 @@ jobs:
           - "2.8"
     steps:
       - uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
       - uses: "actions/setup-python@v2"
         with:
           python-version: "${{ matrix.python-version }}"
@@ -91,3 +93,4 @@ jobs:
         run: "composer dev:test:coverage:ci -- --coverage-text"
       - name: "Publish coverage report to Codecov"
         uses: "codecov/codecov-action@v1"
+        if: ${{ matrix.python-version==3.9 && matrix.php-version==8.0 }}


### PR DESCRIPTION
Hi @ramsey, Tom from Codecov here. I noticed that you were hitting the upload limit on Codecov reports. I wrote up a quick PR that only sends coverage reports when the matrix is at the latest PHP and python versions. Let me know if this makes sense or if you'd like to find a different solution.